### PR TITLE
Improve fetch error messaging

### DIFF
--- a/sitefrontend/script.js
+++ b/sitefrontend/script.js
@@ -151,7 +151,9 @@ async function doFetch() {
 
     await renderProjection();
   } catch (e) {
-    showError(`Profile fetch failed: ${e.message}`);
+    console.error(e.stack);
+    const msg = e?.message || String(e);
+    showError(`Profile fetch failed: ${msg}. Try the Manual backup form.`);
   }
 }
 


### PR DESCRIPTION
## Summary
- Show server error message and hint to try Manual backup form when profile fetch fails
- Log error stack for easier debugging in browser

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b17de6683c832997c12d62c57ff81d