### PR TITLE
Improve RLTracker scraping

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -21,7 +21,7 @@ HTML + CSS + Vanilla JS
 
 Also has an android app with same name just RlRanksPro
 
-Data from Tracker Network API
+Data scraped from Rocket League Tracker pages (no API key needed)
 
 Custom SVG chart drawing
 
@@ -41,7 +41,7 @@ View your projected path.
 
 hosted on RlRanks.Pro
 
-Everything runs client-side; no backend needed.
+Everything runs client-side with a tiny serverless scraper – no external APIs.
 
 License
 


### PR DESCRIPTION
## Summary
- Scrape Rocket League Tracker pages directly with broader JSON parsing and HTML fallbacks
- Update documentation to reflect HTML scraping instead of Tracker Network API

## Testing
- `npm test` *(fails: Missing script "test")*
- `node -e "require('./api/profile.js'); console.log('loaded profile');"`

------
https://chatgpt.com/codex/tasks/task_e_68b17f6a5d748329abf4505dfb6e7189